### PR TITLE
Fix total score sum issue (from #1)

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -111,28 +111,28 @@ function recalculateSums() {
 	$("#reachAuto .taskTotal").text(reachAuto);
 	autoTotal+=reachAuto;
 
-    var boilerLowAuto = Math.floor($('[name="boilerLowAuto"]').val()*1/3);
-    $("#boilerLowAuto .taskTotal").text(boilerLowAuto);
+    var boilerLowAuto = $('[name="boilerLowAuto"]').val()*1/3;
+    $("#boilerLowAuto .taskTotal").text(Math.floor(boilerLowAuto));
     autoTotal+=boilerLowAuto;
 
-    var boilerHighAuto = Math.floor($('[name="boilerHighAuto"]').val()*1);
-    $("#boilerHighAuto .taskTotal").text(boilerHighAuto);
+    var boilerHighAuto = $('[name="boilerHighAuto"]').val()*1;
+    $("#boilerHighAuto .taskTotal").text(Math.floor(boilerHighAuto));
     autoTotal+=boilerHighAuto;
 
     var rotorAuto = $('[name="rotorAuto"]').val()*60;
     $("#rotorAuto .taskTotal").text(rotorAuto);
     autoTotal+=rotorAuto;
 
-	$("#autoSum").text(autoTotal);
+	$("#autoSum").text(Math.floor(autoTotal));
 
 	var teleopTotal = 0;
 
-    var boilerLowTeleop = Math.floor($('[name="boilerLowTeleop"]').val()*1/9);
-    $("#boilerLowTeleop .taskTotal").text(boilerLowTeleop);
+    var boilerLowTeleop = $('[name="boilerLowTeleop"]').val()*1/9;
+    $("#boilerLowTeleop .taskTotal").text(Math.floor(boilerLowTeleop));
     teleopTotal+=boilerLowTeleop;
 
-    var boilerHighTeleop = Math.floor($('[name="boilerHighTeleop"]').val()*1/3);
-    $("#boilerHighTeleop .taskTotal").text(boilerHighTeleop);
+    var boilerHighTeleop = $('[name="boilerHighTeleop"]').val()*1/3;
+    $("#boilerHighTeleop .taskTotal").text(Math.floor(boilerHighTeleop));
     teleopTotal+=boilerHighTeleop;
 
     var rotorTeleop = $('[name="rotorTeleop"]').val()*40;
@@ -143,9 +143,9 @@ function recalculateSums() {
     $("#takeoffReady .taskTotal").text(takeoffReady);
     teleopTotal+=takeoffReady;
 
-	$("#teleopSum").text(teleopTotal);
+	$("#teleopSum").text(Math.floor(teleopTotal));
 
-	$("#totalSum").text(autoTotal+teleopTotal);
+	$("#totalSum").text(Math.floor(autoTotal+teleopTotal));
 }
 
 $(document).ready(function() {


### PR DESCRIPTION
Just realized a complicated issue in my previous PR (#1) where the number of balls scored from auto does not carry over to teleop and the number of balls scored in the low goal are not carried over to the high goal points. This would cause the score to *possibly* be off by 1 point.

For example, if I score 2 (out of 3 required) low goals in autonomous, I should get that point after either depositing 1 teleop high goal or 3 teleop low goals because the `2/3` points I get from auto will add to the `1/3` or `3/9` I get from teleop (i.e. fractional points are added together).

Reference to this can be found on page 41 of the manual:

> Fractions of kilopascals accumulate as an ALLIANCE stokes the BOILER with FUEL in the High and Low Efficiency GOALS [...] MATCH points increment as whole unit kilopascals are achieved.